### PR TITLE
fix the error when options is `{}` or undefined, but the prefix is undefined

### DIFF
--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -4,10 +4,10 @@ import type { App } from 'vue'
 
 interface InstallOptions {
   /** @default `ElIcon` */
-  prefix?: string;
+  prefix?: string
 }
 export default (app: App, options: InstallOptions = {}) => {
-  const { prefix = 'ElIcon' } = options;
+  const { prefix = 'ElIcon' } = options
   for (const [key, component] of Object.entries(icons)) {
     app.component(prefix + key, component)
   }

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -4,9 +4,10 @@ import type { App } from 'vue'
 
 interface InstallOptions {
   /** @default `ElIcon` */
-  prefix?: string
+  prefix?: string;
 }
-export default (app: App, { prefix = 'ElIcon' }: InstallOptions = {}) => {
+export default (app: App, options: InstallOptions = {}) => {
+  const { prefix = 'ElIcon' } = options;
   for (const [key, component] of Object.entries(icons)) {
     app.component(prefix + key, component)
   }


### PR DESCRIPTION
fix the error when options is `{}` or undefined, but the prefix is undefined