### PR TITLE
fix types path error support webstrom

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,23 +24,17 @@
   ],
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
-  "types": "index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
       "require": "./dist/index.cjs",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "types": "./dist/types/index.ts"
     },
     "./global": {
       "require": "./dist/global.cjs",
-      "import": "./dist/global.js"
-    },
-    "./*": "./*"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/types/*"
-      ]
+      "import": "./dist/global.js",
+      "types": "./dist/types/global.ts"
     }
   },
   "unpkg": "dist/index.iife.min.js",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49021590/211188553-d29166b2-5490-4744-98cb-6d363b0b1ca2.png)

typesVersions 不能使用 * 去定义无法识别到path，exports 优先级高于typesVersions 